### PR TITLE
Don't kill git when stopping service

### DIFF
--- a/.openshift/action_hooks/stop
+++ b/.openshift/action_hooks/stop
@@ -5,5 +5,5 @@ if [ -z "$(ps -ef | grep "openscoring" | grep -v grep)" ]
 then
     echo "Application is already stopped"
 else
-    kill `ps -ef | grep "openscoring" | grep -v grep | awk '{ print $2 }'` > /dev/null 2>&1
+    kill `ps -ef | grep "openscoring" | grep -v git | grep -v grep | awk '{ print $2 }'` > /dev/null 2>&1
 fi


### PR DESCRIPTION
OpenShift was terminating the connection when pushing new PMML files
to http://openscoring-ncoghlan.rhcloud.com/

It turned out the git process had "openscoring" in its ps listing.
