### PR TITLE
Use PID to stop server process

### DIFF
--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -4,4 +4,6 @@
 
 cd $OPENSHIFT_REPO_DIR
 
-nohup java -Dconfig.file=application.conf -Djava.util.logging.config.file=logging.properties -cp "target/lib/*" org.openscoring.server.Main --host $OPENSHIFT_DIY_IP --port $OPENSHIFT_DIY_PORT --model-dir "pmml" > ${OPENSHIFT_DIY_LOG_DIR}/openscoring.log 2>&1 &
+java -Dconfig.file=application.conf -Djava.util.logging.config.file=logging.properties -cp "target/lib/*" org.openscoring.server.Main --host $OPENSHIFT_DIY_IP --port $OPENSHIFT_DIY_PORT --model-dir "pmml" > ${OPENSHIFT_DIY_LOG_DIR}/openscoring.log 2>&1 &
+echo $! > $OPENSHIFT_DATA_DIR/openscoring.pid
+disown %1

--- a/.openshift/action_hooks/stop
+++ b/.openshift/action_hooks/stop
@@ -1,9 +1,12 @@
 #!/bin/bash
 # The logic to stop your application should be put in this script.
 
-if [ -z "$(ps -ef | grep "openscoring" | grep -v grep)" ]
+PID_FILE=$OPENSHIFT_DATA_DIR/openscoring.pid
+
+if [ -f $PID_FILE ]
 then
-    echo "Application is already stopped"
+    kill `cat $PID_FILE` > /dev/null 2>&1
+    rm $PID_FILE
 else
-    kill `ps -ef | grep "openscoring" | grep -v grep | awk '{ print $2 }'` > /dev/null 2>&1
+    echo "No PID file at $PID_FILE"
 fi


### PR DESCRIPTION
Using grep to find the right process to stop can be
error prone (e.g. killing the git process handling
a git push).

Switching to a PID file instead ensures only the
relevant server process is stopped.
